### PR TITLE
Update LingvaTranslator.js

### DIFF
--- a/translators/LingvaTranslator.js
+++ b/translators/LingvaTranslator.js
@@ -9,7 +9,7 @@ class LingvaTranslator {
 	apiPath = 'https://lingva.ml';
 
 	translate = (text, from, to) => {
-		return fetch(`${this.apiPath}/api/v1/${from}/${to}/${text}`, {
+		return fetch(`${this.apiPath}/api/v1/${from}/${to}/${encodeURIComponent(text)}`, {
 			credentials: 'omit',
 			headers: {
 				'User-Agent':


### PR DESCRIPTION
If the text that needs to be translated contains a question mark, then the translation stops at that point. encodeURIComponent fixes this.